### PR TITLE
feat: rename editPriceIntervalQuantity to editFixedFeeQuantityTransit…

### DIFF
--- a/src/app/actions/orb.ts
+++ b/src/app/actions/orb.ts
@@ -213,13 +213,13 @@ export async function getCustomerDetails(customerId: string, instance: OrbInstan
   }
 }
 
-export async function editPriceIntervalQuantity(
+export async function editFixedFeeQuantityTransitions(
   subscriptionId: string,
   priceIntervalId: string,
   transitions: FixedFeeQuantityTransition[],
   instance: OrbInstance = 'cloud-infra'
 ): Promise<{ success: boolean; error?: string }> {
-  console.log(`[Action] Editing price interval quantity for sub: ${subscriptionId}, interval: ${priceIntervalId}, instance: ${instance}`);
+  console.log(`[Action] Editing fixed fee quantity transitions for sub: ${subscriptionId}, interval: ${priceIntervalId}, instance: ${instance}`);
   console.log("[Action] Received Transitions:", transitions);
   
   const instanceConfig = ORB_INSTANCES[instance];
@@ -229,7 +229,7 @@ export async function editPriceIntervalQuantity(
     return { success: false, error: 'Server configuration error.' };
   }
   if (!subscriptionId || !priceIntervalId || !transitions || transitions.length === 0) {
-     return { success: false, error: 'Missing required parameters for editing price interval quantity.' };
+     return { success: false, error: 'Missing required parameters for editing fixed fee quantity transitions.' };
   }
 
   const payload = {
@@ -247,12 +247,12 @@ export async function editPriceIntervalQuantity(
     const instanceOrbClient = createOrbClient(instance);
     await instanceOrbClient.subscriptions.priceIntervals(subscriptionId, payload);
 
-    console.log(`[Action] Successfully edited price interval quantity for interval: ${priceIntervalId}`);
+    console.log(`[Action] Successfully edited fixed fee quantity transitions for interval: ${priceIntervalId}`);
     
     return { success: true };
 
   } catch (error) {
-    console.error("[Action] Error during price interval edit process:", error);
+    console.error("[Action] Error during fixed fee quantity transitions edit process:", error);
     const errorMessage = error instanceof Error ? error.message : "An unexpected error occurred.";
     return { success: false, error: errorMessage };
   }

--- a/src/components/customer-dashboard/dialogs/manage-fixed-price-item-dialog.tsx
+++ b/src/components/customer-dashboard/dialogs/manage-fixed-price-item-dialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { editPriceIntervalQuantity, removeFixedFeeQuantityTransition } from "@/app/actions/orb";
+import { editFixedFeeQuantityTransitions, removeFixedFeeQuantityTransition } from "@/app/actions/orb";
 import { toast } from "sonner";
 import { Loader2, Minus, Plus, Trash2 } from "lucide-react";
 import { ApiPreviewDialog } from "../../dialogs/api-preview-dialog";
@@ -169,7 +169,7 @@ export function ManageFixedPriceItemDialog({
     ].sort((a, b) => new Date(a.effective_date).getTime() - new Date(b.effective_date).getTime());
 
     try {
-      const result = await editPriceIntervalQuantity(subscriptionId, priceIntervalId, updatedSchedule, instance);
+      const result = await editFixedFeeQuantityTransitions(subscriptionId, priceIntervalId, updatedSchedule, instance);
       if (result.success) {
         toast.success(`${itemName} Change Scheduled`, {
           description: `Set to ${newQuantityState} effective ${effectiveDateStr}.`,


### PR DESCRIPTION
- Renamed editPriceIntervalQuantity to editFixedFeeQuantityTransitions for better clarity
- Updated function name to accurately reflect its capability to modify both quantities and effective dates
- Updated import in manage-fixed-price-item-dialog.tsx component
- Added comprehensive behavior-driven tests for editFixedFeeQuantityTransitions function:
  - Success scenarios for both cloud-infra and ai-agents instances
  - Single and multiple transition handling
  - Parameter validation and error handling
  - API configuration error handling
  - Zero quantity and enterprise-scale quantity scenarios
- Added comprehensive behavior-driven tests for addPriceInterval function:
  - Success scenarios with provided and default dates
  - UTC date handling and timezone edge cases
  - Date format validation
  - Parameter validation and error handling
  - API configuration and error handling
- Fixed ESLint violations by replacing require() with proper ES6 imports
- Used Object.defineProperty to properly mock read-only properties in tests
- All tests passing with improved type safety

🤖 Generated with [Claude Code](https://claude.ai/code)