### PR TITLE
feat: add event ingestion functionality for AI agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.1.0",
         "tw-animate-css": "^1.2.5",
+        "uuid": "^11.1.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -46,6 +47,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/stripe": "^8.0.416",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.2.4",
         "jest": "^29.7.0",
@@ -4654,6 +4656,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12514,6 +12523,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -48,6 +49,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/stripe": "^8.0.416",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "jest": "^29.7.0",

--- a/src/components/customer-dashboard/cards/events-card.tsx
+++ b/src/components/customer-dashboard/cards/events-card.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import React, { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { sendRandomizedEvent } from "@/app/actions/orb"
+import type { OrbInstance } from "@/lib/orb-config"
+import type { SendEventResult } from "@/lib/events/types"
+import { toast } from "sonner"
+
+interface EventsCardProps {
+  customerId: string;
+  instance: OrbInstance;
+}
+
+export function EventsCard({ customerId, instance }: EventsCardProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastResult, setLastResult] = useState<SendEventResult | null>(null);
+
+  const handleSendEvent = async (testMode: boolean = false) => {
+    setIsLoading(true);
+    try {
+      const result = await sendRandomizedEvent(customerId, instance, undefined, testMode);
+      setLastResult(result);
+      
+      if (result.success) {
+        toast.success(
+          testMode 
+            ? "Test event generated successfully!" 
+            : "Event sent to Orb successfully!"
+        );
+      } else {
+        toast.error(`Failed to send event: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Error sending event:', error);
+      toast.error('Unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Event Ingestion</CardTitle>
+        <CardDescription>
+          Send events to Orb for the current customer using the {instance} instance.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex gap-4 mb-4">
+          <Button 
+            onClick={() => handleSendEvent(true)}
+            disabled={isLoading}
+            variant="outline"
+          >
+            {isLoading ? "Generating..." : "Test Mode"}
+          </Button>
+          <Button 
+            onClick={() => handleSendEvent(false)}
+            disabled={isLoading}
+          >
+            {isLoading ? "Sending..." : "Send to Orb"}
+          </Button>
+        </div>
+
+        {lastResult && (
+          <div className="mt-4">
+            <p className="text-sm font-medium mb-2">
+              {lastResult.success ? "✅ Success!" : "❌ Error"}
+            </p>
+            
+            {lastResult.error && (
+              <p className="text-sm text-red-600 mb-2">{lastResult.error}</p>
+            )}
+            
+            {lastResult.event && (
+              <div>
+                <p className="text-sm font-medium mb-1">Generated Event:</p>
+                <pre className="text-xs bg-gray-100 p-2 rounded overflow-x-auto">
+                  {JSON.stringify(lastResult.event, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/customer-dashboard/dashboard-content.tsx
+++ b/src/components/customer-dashboard/dashboard-content.tsx
@@ -23,6 +23,7 @@ import { useCustomerSubscriptions, useCustomerDetails } from "@/hooks/useCustome
 import { SubscriptionDetailsCard } from "./cards/subscription-details-card";
 import { EntitlementsCard } from "./cards/entitlements-card";
 import { CustomerPortalCard } from "./cards/customer-portal-card";
+import { EventsCard } from "./cards/events-card";
 import { removeFixedFeeQuantityTransition } from "@/app/actions/orb";
 import { toast } from "sonner";
 import { formatDate } from "@/lib/utils/formatters";
@@ -279,6 +280,7 @@ export function CustomerDashboardContent({ customerId: customerIdProp, instance:
             <TabsList>
               <TabsTrigger value="subscriptions">Subscriptions</TabsTrigger>
               <TabsTrigger value="customer-portal">Customer Portal</TabsTrigger>
+              <TabsTrigger value="events">Events</TabsTrigger>
             </TabsList>
             <TabsContent value="subscriptions">
               <div className="grid gap-6 md:grid-cols-2">
@@ -335,6 +337,7 @@ export function CustomerDashboardContent({ customerId: customerIdProp, instance:
             <TabsList>
               <TabsTrigger value="subscriptions">Subscriptions</TabsTrigger>
               <TabsTrigger value="customer-portal">Customer Portal</TabsTrigger>
+              <TabsTrigger value="events">Events</TabsTrigger>
             </TabsList>
             <TabsContent value="subscriptions">
               <div className="grid gap-6 md:grid-cols-2">
@@ -357,6 +360,9 @@ export function CustomerDashboardContent({ customerId: customerIdProp, instance:
             </TabsContent>
             <TabsContent value="customer-portal">
               <CustomerPortalCard portalUrl={customerDetails?.portal_url} />
+            </TabsContent>
+            <TabsContent value="events">
+              <EventsCard customerId={stableCustomerId!} instance={currentInstance!} />
             </TabsContent>
           </Tabs>
       </main>

--- a/src/lib/events/event-templates.ts
+++ b/src/lib/events/event-templates.ts
@@ -1,0 +1,44 @@
+import type { EventTemplate } from './types';
+
+// AI Agents event template
+export const AI_AGENTS_TEMPLATE: EventTemplate = {
+  eventName: 'agent_request',
+  properties: {
+    model: {
+      type: 'enum',
+      options: [
+        'claude-opus-4',
+        'claude-sonnet-4', 
+        'claude-sonnet-3.7',
+        'o3',
+        'o4-mini',
+        'gemini-2.5-flash',
+        'gemini-2.5-pro'
+      ],
+      default: 'claude-sonnet-4'
+    },
+    num_steps: {
+      type: 'range',
+      min: 1,
+      max: 100,
+      default: 50
+    },
+    num_tokens: {
+      type: 'range',
+      min: 100,
+      max: 10000,
+      default: 1000
+    },
+    user_id: {
+      type: 'enum',
+      options: ['Sarah', 'Hari', 'Taylor', 'Marshall'],
+      default: 'Sarah'
+    }
+  }
+};
+
+// Template registry by instance
+export const EVENT_TEMPLATES = {
+  'ai-agents': AI_AGENTS_TEMPLATE,
+  // 'cloud-infra': CLOUD_INFRA_TEMPLATE // Future implementation
+} as const;

--- a/src/lib/events/payload-builder.ts
+++ b/src/lib/events/payload-builder.ts
@@ -1,0 +1,122 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { OrbEvent, PropertyTemplate } from './types';
+import type { OrbInstance } from '@/lib/orb-config';
+import { EVENT_TEMPLATES } from './event-templates';
+
+// Generate a random value based on property template
+function generateRandomValue(template: PropertyTemplate): string | number {
+  switch (template.type) {
+    case 'enum':
+      if (!template.options || template.options.length === 0) {
+        throw new Error('Enum template must have options');
+      }
+      const randomIndex = Math.floor(Math.random() * template.options.length);
+      return template.options[randomIndex];
+    
+    case 'range':
+      if (template.min === undefined || template.max === undefined) {
+        throw new Error('Range template must have min and max values');
+      }
+      return Math.floor(Math.random() * (template.max - template.min + 1)) + template.min;
+    
+    case 'string':
+      return template.default as string || 'default_value';
+    
+    default:
+      throw new Error(`Unknown template type: ${(template as PropertyTemplate).type}`);
+  }
+}
+
+// Generate idempotency key with UUID + timestamp suffix
+function generateIdempotencyKey(): string {
+  const uuid = uuidv4();
+  const timestamp = new Date().toISOString().replace(/[-:T.]/g, '').slice(0, 14); // YYYYMMDDHHMMSS
+  return `${uuid}_${timestamp}`;
+}
+
+// Generate current UTC timestamp in ISO format
+function generateTimestamp(): string {
+  return new Date().toISOString();
+}
+
+// Build event payload with randomized property values
+export function buildRandomizedEventPayload(
+  instance: OrbInstance,
+  customerId: string,
+  externalCustomerId?: string
+): OrbEvent {
+  // For now, only support AI agents instance
+  if (instance !== 'ai-agents') {
+    throw new Error(`Event templates only available for ai-agents instance currently`);
+  }
+
+  const template = EVENT_TEMPLATES[instance];
+  if (!template) {
+    throw new Error(`No event template found for instance: ${instance}`);
+  }
+
+  // Generate randomized properties
+  const properties: Record<string, string | number | boolean> = {};
+  for (const [key, propertyTemplate] of Object.entries(template.properties)) {
+    properties[key] = generateRandomValue(propertyTemplate);
+  }
+
+  // Build the event object
+  const event: OrbEvent = {
+    idempotency_key: generateIdempotencyKey(),
+    event_name: template.eventName,
+    timestamp: generateTimestamp(),
+    properties,
+    ...(externalCustomerId 
+      ? { external_customer_id: externalCustomerId }
+      : { customer_id: customerId }
+    )
+  };
+
+  return event;
+}
+
+// Build event payload with manual property values
+export function buildManualEventPayload(
+  instance: OrbInstance,
+  customerId: string,
+  manualProperties: Record<string, string | number | boolean>,
+  externalCustomerId?: string
+): OrbEvent {
+  // For now, only support AI agents instance
+  if (instance !== 'ai-agents') {
+    throw new Error(`Event templates only available for ai-agents instance currently`);
+  }
+
+  const template = EVENT_TEMPLATES[instance];
+  if (!template) {
+    throw new Error(`No event template found for instance: ${instance}`);
+  }
+
+  // Use manual properties, falling back to defaults for missing values
+  const properties: Record<string, string | number | boolean> = {};
+  for (const [key, propertyTemplate] of Object.entries(template.properties)) {
+    if (key in manualProperties) {
+      properties[key] = manualProperties[key];
+    } else if (propertyTemplate.default !== undefined) {
+      properties[key] = propertyTemplate.default;
+    } else {
+      // Generate random value as fallback
+      properties[key] = generateRandomValue(propertyTemplate);
+    }
+  }
+
+  // Build the event object
+  const event: OrbEvent = {
+    idempotency_key: generateIdempotencyKey(),
+    event_name: template.eventName,
+    timestamp: generateTimestamp(),
+    properties,
+    ...(externalCustomerId 
+      ? { external_customer_id: externalCustomerId }
+      : { customer_id: customerId }
+    )
+  };
+
+  return event;
+}

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -1,0 +1,54 @@
+// Event schema types based on Orb API documentation
+// https://docs.withorb.com/api-reference/event/ingest-events
+
+export type OrbEvent = {
+  idempotency_key: string;
+  event_name: string;
+  timestamp: string; // ISO 8601 format with UTC timezone (YYYY-MM-DDTHH:MM:SSZ)
+  properties: Record<string, string | number | boolean>; // Required by Orb SDK
+} & (
+  | { customer_id: string; external_customer_id?: never }
+  | { external_customer_id: string; customer_id?: never }
+);
+
+export type IngestEventsRequest = {
+  events: OrbEvent[];
+};
+
+export type IngestEventsResponse = {
+  // Orb API response structure - using flexible type to match SDK
+  [key: string]: unknown;
+} | unknown;
+
+// AI Agents specific event properties
+export type AIAgentEventProperties = {
+  model: string;
+  num_steps: number;
+  num_tokens: number;
+  user_id: string;
+};
+
+// Template configuration types
+export type PropertyTemplate = {
+  type: 'enum' | 'range' | 'string';
+  options?: string[];
+  min?: number;
+  max?: number;
+  default?: string | number;
+};
+
+export type EventTemplate = {
+  eventName: string;
+  properties: Record<string, PropertyTemplate>;
+};
+
+// Server action result types
+export type SendEventResult = {
+  success: boolean;
+  event?: OrbEvent;
+  error?: string;
+  debug?: {
+    payload: IngestEventsRequest;
+    response?: unknown;
+  };
+};


### PR DESCRIPTION
- Add comprehensive event ingestion system with randomized payload generation
- Create AI agents event template with configurable ranges for models, tokens, steps, and users
- Add test mode for previewing payloads without sending to Orb
- Implement new Events tab in customer dashboard with simple UI

Core Features:
- sendRandomizedEvent() and sendManualEvent() server actions in orb.ts
- Payload builder with UUID generation and UTC timestamps
- Event templates supporting enum options and numeric ranges
- Events card component with Test Mode and Send to Orb buttons

Event Template Configuration:
- Models: claude-opus-4, claude-sonnet-4, claude-sonnet-3.7, o3, o4-mini, gemini-2.5-flash, gemini-2.5-pro
- Tokens: 100-10,000 range
- Steps: 1-100 range
- Users: Sarah, Hari, Taylor, Marshall

Files Added:
- src/lib/events/types.ts - TypeScript event schema types
- src/lib/events/event-templates.ts - AI agents template configuration
- src/lib/events/payload-builder.ts - Randomized payload generation utilities
- src/components/customer-dashboard/cards/events-card.tsx - Events UI component

Dependencies:
- Added uuid package for idempotency key generation

🤖 Generated with [Claude Code](https://claude.ai/code)