### PR TITLE
feat: add cloud infrastructure network request events UI

### DIFF
--- a/src/components/customer-dashboard/cards/events-card.tsx
+++ b/src/components/customer-dashboard/cards/events-card.tsx
@@ -2,92 +2,72 @@
 
 import React, { useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import { Input } from "@/components/ui/input"
-import { Skeleton } from "@/components/ui/skeleton"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectGroup, SelectLabel } from "@/components/ui/select"
-import { sendRandomizedEvent, sendManualEvent } from "@/app/actions/orb"
-import type { OrbInstance } from "@/lib/orb-config"
+import { useCustomerStore } from "@/lib/store/customer-store"
 import type { SendEventResult } from "@/lib/events/types"
 import type { Subscription } from "@/lib/types"
-import { AI_AGENTS_TEMPLATE } from "@/lib/events/event-templates"
-import { usePremiumModelAccess } from "@/hooks/usePremiumModelAccess"
-import { toast } from "sonner"
+import { AiAgentsEventsForm } from "./events/ai-agents-events-form"
+import { CloudInfraEventsForm } from "./events/cloud-infra-events-form"
+import { GenericEventsForm } from "./events/generic-events-form"
 
 interface EventsCardProps {
   customerId: string;
-  instance: OrbInstance;
   subscription?: Subscription | null;
 }
 
-export function EventsCard({ customerId, instance, subscription }: EventsCardProps) {
-  const [isLoading, setIsLoading] = useState(false);
+export function EventsCard({ customerId, subscription }: EventsCardProps) {
   const [lastResult, setLastResult] = useState<SendEventResult | null>(null);
   
-  // Manual event form state
-  const [manualProperties, setManualProperties] = useState<Record<string, string | number>>({});
+  // Get instance from store
+  const instance = useCustomerStore((state) => state.selectedInstance);
   
-  // Check if this is the AI agents instance to show manual controls
-  const isAiAgentsInstance = instance === 'ai-agents';
-  
-  // Get all available models for this instance
-  const allModels = AI_AGENTS_TEMPLATE.properties.model.options || [];
-  
-  // Get premium model access information
-  const modelAccess = usePremiumModelAccess(subscription, instance, allModels);
+  // Don't render if no instance is selected
+  if (!instance) {
+    return (
+      <div className="flex justify-center">
+        <Card className="w-full max-w-lg">
+          <CardHeader className="text-center">
+            <CardTitle>Event Ingestion</CardTitle>
+            <CardDescription>
+              Please select an instance to send events.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
 
-  const handleSendEvent = async (testMode: boolean = false) => {
-    setIsLoading(true);
-    try {
-      const result = await sendRandomizedEvent(customerId, instance, undefined, testMode);
-      setLastResult(result);
-      
-      if (result.success) {
-        toast.success(
-          testMode 
-            ? "Test event generated successfully!" 
-            : "Event sent to Orb successfully!"
-        );
-      } else {
-        toast.error(`Failed to send event: ${result.error}`);
-      }
-    } catch (error) {
-      console.error('Error sending event:', error);
-      toast.error('Unexpected error occurred');
-    } finally {
-      setIsLoading(false);
-    }
+  const handleResult = (result: SendEventResult) => {
+    setLastResult(result);
   };
 
-  const handleSendManualEvent = async (testMode: boolean = false) => {
-    setIsLoading(true);
-    try {
-      const result = await sendManualEvent(customerId, instance, manualProperties, undefined, testMode);
-      setLastResult(result);
-      
-      if (result.success) {
-        toast.success(
-          testMode 
-            ? "Custom event generated successfully!" 
-            : "Custom event sent to Orb successfully!"
+  const renderEventForm = () => {
+    switch (instance) {
+      case 'ai-agents':
+        return (
+          <AiAgentsEventsForm
+            customerId={customerId}
+            instance={instance}
+            subscription={subscription}
+            onResult={handleResult}
+          />
         );
-      } else {
-        toast.error(`Failed to send custom event: ${result.error}`);
-      }
-    } catch (error) {
-      console.error('Error sending custom event:', error);
-      toast.error('Unexpected error occurred');
-    } finally {
-      setIsLoading(false);
+      case 'cloud-infra':
+        return (
+          <CloudInfraEventsForm
+            customerId={customerId}
+            instance={instance}
+            onResult={handleResult}
+          />
+        );
+      default:
+        return (
+          <GenericEventsForm
+            customerId={customerId}
+            instance={instance}
+            onResult={handleResult}
+          />
+        );
     }
-  };
-
-  const handlePropertyChange = (key: string, value: string | number) => {
-    setManualProperties(prev => ({
-      ...prev,
-      [key]: value
-    }));
   };
 
   return (
@@ -100,166 +80,28 @@ export function EventsCard({ customerId, instance, subscription }: EventsCardPro
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {isAiAgentsInstance ? (
-            <div className="space-y-6">
-              <div className="space-y-2">
-                <Label htmlFor="model">Model</Label>
-                {modelAccess.isLoading ? (
-                  <Skeleton className="h-9 w-full" />
-                ) : modelAccess.error ? (
-                  <div className="p-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded">
-                    {modelAccess.error}
-                  </div>
-                ) : (
-                  <Select 
-                    value={manualProperties.model as string || ''} 
-                    onValueChange={(value) => handlePropertyChange('model', value)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select model..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {/* Standard models - always available */}
-                      {modelAccess.standardModels.length > 0 && (
-                        <SelectGroup>
-                          <SelectLabel>Standard Models</SelectLabel>
-                          {modelAccess.standardModels.map(model => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      )}
-                      
-                      {/* Premium models - available or restricted */}
-                      {modelAccess.premiumModels.length > 0 && (
-                        <SelectGroup>
-                          <SelectLabel>Premium Models</SelectLabel>
-                          {modelAccess.premiumModels.map(model => (
-                            <SelectItem 
-                              key={model} 
-                              value={model}
-                              disabled={!modelAccess.hasAccess}
-                              className={!modelAccess.hasAccess ? "text-muted-foreground" : ""}
-                            >
-                              {model}{!modelAccess.hasAccess ? " (Upgrade Required)" : ""}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      )}
-                    </SelectContent>
-                  </Select>
-                )}
-                
-                {/* Show upgrade message for restricted premium models */}
-                {!modelAccess.isLoading && !modelAccess.error && !modelAccess.hasAccess && modelAccess.premiumModels.length > 0 && (
-                  <p className="text-xs text-muted-foreground mt-2">
-                    Add Premium Models to your subscription or upgrade your plan to access {modelAccess.premiumModels.join(", ")}
-                  </p>
-                )}
-              </div>
+          {renderEventForm()}
 
-              <div className="space-y-2">
-                <Label htmlFor="user_id">User</Label>
-                <Select 
-                  value={manualProperties.user_id as string || ''} 
-                  onValueChange={(value) => handlePropertyChange('user_id', value)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select user..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {AI_AGENTS_TEMPLATE.properties.user_id.options?.map(user => (
-                      <SelectItem key={user} value={user}>{user}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+          {lastResult && (
+            <div className="mt-4">
+              <p className="text-sm font-medium mb-2">
+                {lastResult.success ? "✅ Success!" : "❌ Error"}
+              </p>
               
-              <div className="space-y-2">
-                <Label htmlFor="num_steps">Number of Steps</Label>
-                <Input
-                  id="num_steps"
-                  type="number"
-                  min={AI_AGENTS_TEMPLATE.properties.num_steps.min}
-                  max={AI_AGENTS_TEMPLATE.properties.num_steps.max}
-                  placeholder={`${AI_AGENTS_TEMPLATE.properties.num_steps.min}-${AI_AGENTS_TEMPLATE.properties.num_steps.max}`}
-                  value={manualProperties.num_steps || ''}
-                  onChange={(e) => handlePropertyChange('num_steps', Number(e.target.value))}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="num_tokens">Number of Tokens</Label>
-                <Input
-                  id="num_tokens"
-                  type="number"
-                  min={AI_AGENTS_TEMPLATE.properties.num_tokens.min}
-                  max={AI_AGENTS_TEMPLATE.properties.num_tokens.max}
-                  placeholder={`${AI_AGENTS_TEMPLATE.properties.num_tokens.min}-${AI_AGENTS_TEMPLATE.properties.num_tokens.max}`}
-                  value={manualProperties.num_tokens || ''}
-                  onChange={(e) => handlePropertyChange('num_tokens', Number(e.target.value))}
-                />
-              </div>
-
-              <div className="flex gap-3 pt-2">
-                <Button 
-                  onClick={() => handleSendManualEvent(true)}
-                  disabled={isLoading}
-                  variant="outline"
-                  className="flex-1"
-                >
-                  {isLoading ? "Generating..." : "Test Event"}
-                </Button>
-                <Button 
-                  onClick={() => handleSendManualEvent(false)}
-                  disabled={isLoading}
-                  className="flex-1"
-                >
-                  {isLoading ? "Sending..." : "Send Event"}
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="flex gap-3">
-              <Button 
-                onClick={() => handleSendEvent(true)}
-                disabled={isLoading}
-                variant="outline"
-                className="flex-1"
-              >
-                {isLoading ? "Generating..." : "Test Mode"}
-              </Button>
-              <Button 
-                onClick={() => handleSendEvent(false)}
-                disabled={isLoading}
-                className="flex-1"
-              >
-                {isLoading ? "Sending..." : "Send to Orb"}
-              </Button>
+              {lastResult.error && (
+                <p className="text-sm text-red-600 mb-2">{lastResult.error}</p>
+              )}
+              
+              {lastResult.event && (
+                <div>
+                  <p className="text-sm font-medium mb-1">Generated Event:</p>
+                  <pre className="text-xs bg-gray-100 p-2 rounded overflow-x-auto">
+                    {JSON.stringify(lastResult.event, null, 2)}
+                  </pre>
+                </div>
+              )}
             </div>
           )}
-
-        {lastResult && (
-          <div className="mt-4">
-            <p className="text-sm font-medium mb-2">
-              {lastResult.success ? "✅ Success!" : "❌ Error"}
-            </p>
-            
-            {lastResult.error && (
-              <p className="text-sm text-red-600 mb-2">{lastResult.error}</p>
-            )}
-            
-            {lastResult.event && (
-              <div>
-                <p className="text-sm font-medium mb-1">Generated Event:</p>
-                <pre className="text-xs bg-gray-100 p-2 rounded overflow-x-auto">
-                  {JSON.stringify(lastResult.event, null, 2)}
-                </pre>
-              </div>
-            )}
-          </div>
-        )}
         </CardContent>
       </Card>
     </div>

--- a/src/components/customer-dashboard/cards/events/ai-agents-events-form.tsx
+++ b/src/components/customer-dashboard/cards/events/ai-agents-events-form.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import React, { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SelectGroup, SelectLabel } from "@/components/ui/select"
+import { sendManualEvent } from "@/app/actions/orb"
+import { AI_AGENTS_TEMPLATE } from "@/lib/events/event-templates"
+import { usePremiumModelAccess } from "@/hooks/usePremiumModelAccess"
+import type { SendEventResult } from "@/lib/events/types"
+import type { Subscription } from "@/lib/types"
+import { toast } from "sonner"
+
+interface AiAgentsEventsFormProps {
+  customerId: string;
+  instance: 'ai-agents';
+  subscription?: Subscription | null;
+  onResult: (result: SendEventResult) => void;
+}
+
+export function AiAgentsEventsForm({ customerId, instance, subscription, onResult }: AiAgentsEventsFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [manualProperties, setManualProperties] = useState<Record<string, string | number>>({});
+
+  // Get all available models for this instance
+  const allModels = AI_AGENTS_TEMPLATE.properties.model.options || [];
+  
+  // Get premium model access information
+  const modelAccess = usePremiumModelAccess(subscription, instance, allModels);
+
+  const handlePropertyChange = (key: string, value: string | number) => {
+    setManualProperties(prev => ({
+      ...prev,
+      [key]: value
+    }));
+  };
+
+  const handleSendEvent = async (testMode: boolean = false) => {
+    setIsLoading(true);
+    try {
+      const result = await sendManualEvent(customerId, instance, manualProperties, undefined, testMode);
+      onResult(result);
+      
+      if (result.success) {
+        toast.success(
+          testMode 
+            ? "AI agent event generated successfully!" 
+            : "AI agent event sent to Orb successfully!"
+        );
+      } else {
+        toast.error(`Failed to send event: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Error sending event:', error);
+      toast.error('Unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="model">Model</Label>
+        {modelAccess.isLoading ? (
+          <Skeleton className="h-9 w-full" />
+        ) : modelAccess.error ? (
+          <div className="p-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded">
+            {modelAccess.error}
+          </div>
+        ) : (
+          <Select 
+            value={manualProperties.model as string || ''} 
+            onValueChange={(value) => handlePropertyChange('model', value)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select model..." />
+            </SelectTrigger>
+            <SelectContent>
+              {/* Standard models - always available */}
+              {modelAccess.standardModels.length > 0 && (
+                <SelectGroup>
+                  <SelectLabel>Standard Models</SelectLabel>
+                  {modelAccess.standardModels.map(model => (
+                    <SelectItem key={model} value={model}>
+                      {model}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              )}
+              
+              {/* Premium models - available or restricted */}
+              {modelAccess.premiumModels.length > 0 && (
+                <SelectGroup>
+                  <SelectLabel>Premium Models</SelectLabel>
+                  {modelAccess.premiumModels.map(model => (
+                    <SelectItem 
+                      key={model} 
+                      value={model}
+                      disabled={!modelAccess.hasAccess}
+                      className={!modelAccess.hasAccess ? "text-muted-foreground" : ""}
+                    >
+                      {model}{!modelAccess.hasAccess ? " (Upgrade Required)" : ""}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              )}
+            </SelectContent>
+          </Select>
+        )}
+        
+        {/* Show upgrade message for restricted premium models */}
+        {!modelAccess.isLoading && !modelAccess.error && !modelAccess.hasAccess && modelAccess.premiumModels.length > 0 && (
+          <p className="text-xs text-muted-foreground mt-2">
+            Add Premium Models to your subscription or upgrade your plan to access {modelAccess.premiumModels.join(", ")}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="user_id">User</Label>
+        <Select 
+          value={manualProperties.user_id as string || ''} 
+          onValueChange={(value) => handlePropertyChange('user_id', value)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select user..." />
+          </SelectTrigger>
+          <SelectContent>
+            {AI_AGENTS_TEMPLATE.properties.user_id.options?.map(user => (
+              <SelectItem key={user} value={user}>{user}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      
+      <div className="space-y-2">
+        <Label htmlFor="num_steps">Number of Steps</Label>
+        <Input
+          id="num_steps"
+          type="number"
+          min={AI_AGENTS_TEMPLATE.properties.num_steps.min}
+          max={AI_AGENTS_TEMPLATE.properties.num_steps.max}
+          placeholder={`${AI_AGENTS_TEMPLATE.properties.num_steps.min}-${AI_AGENTS_TEMPLATE.properties.num_steps.max}`}
+          value={manualProperties.num_steps || ''}
+          onChange={(e) => handlePropertyChange('num_steps', Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="num_tokens">Number of Tokens</Label>
+        <Input
+          id="num_tokens"
+          type="number"
+          min={AI_AGENTS_TEMPLATE.properties.num_tokens.min}
+          max={AI_AGENTS_TEMPLATE.properties.num_tokens.max}
+          placeholder={`${AI_AGENTS_TEMPLATE.properties.num_tokens.min}-${AI_AGENTS_TEMPLATE.properties.num_tokens.max}`}
+          value={manualProperties.num_tokens || ''}
+          onChange={(e) => handlePropertyChange('num_tokens', Number(e.target.value))}
+        />
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button 
+          onClick={() => handleSendEvent(true)}
+          disabled={isLoading}
+          variant="outline"
+          className="flex-1"
+        >
+          {isLoading ? "Generating..." : "Test Event"}
+        </Button>
+        <Button 
+          onClick={() => handleSendEvent(false)}
+          disabled={isLoading}
+          className="flex-1"
+        >
+          {isLoading ? "Sending..." : "Send Event"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customer-dashboard/cards/events/cloud-infra-events-form.tsx
+++ b/src/components/customer-dashboard/cards/events/cloud-infra-events-form.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import React, { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { sendManualEvent } from "@/app/actions/orb"
+import { CLOUD_INFRA_TEMPLATE } from "@/lib/events/event-templates"
+import type { SendEventResult } from "@/lib/events/types"
+import { toast } from "sonner"
+
+interface CloudInfraEventsFormProps {
+  customerId: string;
+  instance: 'cloud-infra';
+  onResult: (result: SendEventResult) => void;
+}
+
+export function CloudInfraEventsForm({ customerId, instance, onResult }: CloudInfraEventsFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [manualProperties, setManualProperties] = useState<Record<string, string | number>>({});
+
+  const handlePropertyChange = (key: string, value: string | number) => {
+    setManualProperties(prev => ({
+      ...prev,
+      [key]: value
+    }));
+  };
+
+  const handleSendEvent = async (testMode: boolean = false) => {
+    setIsLoading(true);
+    try {
+      const result = await sendManualEvent(customerId, instance, manualProperties, undefined, testMode);
+      onResult(result);
+      
+      if (result.success) {
+        toast.success(
+          testMode 
+            ? "Network request event generated successfully!" 
+            : "Network request event sent to Orb successfully!"
+        );
+      } else {
+        toast.error(`Failed to send event: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Error sending event:', error);
+      toast.error('Unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Label htmlFor="bandwidth_bytes">Bandwidth (bytes)</Label>
+        <Input
+          id="bandwidth_bytes"
+          type="number"
+          min={CLOUD_INFRA_TEMPLATE.properties.bandwidth_bytes.min}
+          max={CLOUD_INFRA_TEMPLATE.properties.bandwidth_bytes.max}
+          placeholder={`${CLOUD_INFRA_TEMPLATE.properties.bandwidth_bytes.min}-${CLOUD_INFRA_TEMPLATE.properties.bandwidth_bytes.max}`}
+          value={manualProperties.bandwidth_bytes || ''}
+          onChange={(e) => handlePropertyChange('bandwidth_bytes', Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="runtime">Runtime</Label>
+        <Select 
+          value={manualProperties.runtime as string || ''} 
+          onValueChange={(value) => handlePropertyChange('runtime', value)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select runtime..." />
+          </SelectTrigger>
+          <SelectContent>
+            {CLOUD_INFRA_TEMPLATE.properties.runtime.options?.map(runtime => (
+              <SelectItem key={runtime} value={runtime}>{runtime}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button 
+          onClick={() => handleSendEvent(true)}
+          disabled={isLoading}
+          variant="outline"
+          className="flex-1"
+        >
+          {isLoading ? "Generating..." : "Test Event"}
+        </Button>
+        <Button 
+          onClick={() => handleSendEvent(false)}
+          disabled={isLoading}
+          className="flex-1"
+        >
+          {isLoading ? "Sending..." : "Send Event"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customer-dashboard/cards/events/generic-events-form.tsx
+++ b/src/components/customer-dashboard/cards/events/generic-events-form.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import React, { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { sendRandomizedEvent } from "@/app/actions/orb"
+import type { OrbInstance } from "@/lib/orb-config"
+import type { SendEventResult } from "@/lib/events/types"
+import { toast } from "sonner"
+
+interface GenericEventsFormProps {
+  customerId: string;
+  instance: OrbInstance;
+  onResult: (result: SendEventResult) => void;
+}
+
+export function GenericEventsForm({ customerId, instance, onResult }: GenericEventsFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSendEvent = async (testMode: boolean = false) => {
+    setIsLoading(true);
+    try {
+      const result = await sendRandomizedEvent(customerId, instance, undefined, testMode);
+      onResult(result);
+      
+      if (result.success) {
+        toast.success(
+          testMode 
+            ? "Test event generated successfully!" 
+            : "Event sent to Orb successfully!"
+        );
+      } else {
+        toast.error(`Failed to send event: ${result.error}`);
+      }
+    } catch (error) {
+      console.error('Error sending event:', error);
+      toast.error('Unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex gap-3">
+      <Button 
+        onClick={() => handleSendEvent(true)}
+        disabled={isLoading}
+        variant="outline"
+        className="flex-1"
+      >
+        {isLoading ? "Generating..." : "Test Mode"}
+      </Button>
+      <Button 
+        onClick={() => handleSendEvent(false)}
+        disabled={isLoading}
+        className="flex-1"
+      >
+        {isLoading ? "Sending..." : "Send to Orb"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/customer-dashboard/dashboard-content.tsx
+++ b/src/components/customer-dashboard/dashboard-content.tsx
@@ -364,7 +364,6 @@ export function CustomerDashboardContent({ customerId: customerIdProp, instance:
             <TabsContent value="events">
               <EventsCard 
                 customerId={stableCustomerId!} 
-                instance={currentInstance!} 
                 subscription={activeSubscription}
               />
             </TabsContent>

--- a/src/lib/events/__tests__/event-templates.test.ts
+++ b/src/lib/events/__tests__/event-templates.test.ts
@@ -135,14 +135,15 @@ describe('Event Templates', () => {
       const template = EVENT_TEMPLATES['cloud-infra'];
       
       expect(template.eventName).toBe('Nimbus_Scale_Network_Request');
-      expect(template.properties.bandwidth_MB).toMatchObject({
+      expect(template.properties.bandwidth_bytes).toMatchObject({
         type: 'range',
-        min: 100,
-        max: 10000
+        min: 10000000,
+        max: 100000000
       });
       expect(template.properties.runtime).toMatchObject({
         type: 'enum',
-        options: ['node', 'edge']
+        options: ['node', 'edge'],
+        default: 'edge'
       });
     });
 
@@ -152,8 +153,8 @@ describe('Event Templates', () => {
       expect(event.event_name).toBe('Nimbus_Scale_Network_Request');
       expect(event.external_customer_id).toBe('acme');
       expect(event.customer_id).toBeUndefined();
-      expect(event.properties.bandwidth_MB).toBeGreaterThanOrEqual(100);
-      expect(event.properties.bandwidth_MB).toBeLessThanOrEqual(10000);
+      expect(event.properties.bandwidth_bytes).toBeGreaterThanOrEqual(10000000);
+      expect(event.properties.bandwidth_bytes).toBeLessThanOrEqual(100000000);
       expect(['node', 'edge']).toContain(event.properties.runtime);
       expect(event.idempotency_key).toMatch(/^[0-9a-f-]{36}_\d{14}$/);
       expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
@@ -161,7 +162,7 @@ describe('Event Templates', () => {
 
     it('should generate valid cloud infra events with manual properties', () => {
       const manualProperties = {
-        bandwidth_MB: 5027,
+        bandwidth_bytes: 50000000,
         runtime: 'node'
       };
       
@@ -170,17 +171,17 @@ describe('Event Templates', () => {
       expect(event.event_name).toBe('Nimbus_Scale_Network_Request');
       expect(event.external_customer_id).toBe('acme');
       expect(event.customer_id).toBeUndefined();
-      expect(event.properties.bandwidth_MB).toBe(5027);
+      expect(event.properties.bandwidth_bytes).toBe(50000000);
       expect(event.properties.runtime).toBe('node');
       expect(event.idempotency_key).toMatch(/^[0-9a-f-]{36}_\d{14}$/);
       expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     });
 
-    it('should validate bandwidth_MB is within acceptable range', () => {
+    it('should validate bandwidth_bytes is within acceptable range', () => {
       const template = EVENT_TEMPLATES['cloud-infra'];
       
-      expect(template.properties.bandwidth_MB.min).toBe(100);
-      expect(template.properties.bandwidth_MB.max).toBe(10000);
+      expect(template.properties.bandwidth_bytes.min).toBe(10000000);
+      expect(template.properties.bandwidth_bytes.max).toBe(100000000);
     });
 
     it('should validate runtime options are node or edge', () => {
@@ -189,15 +190,15 @@ describe('Event Templates', () => {
       expect(template.properties.runtime.options).toEqual(['node', 'edge']);
     });
 
-    it('should generate randomized bandwidth_MB values within valid range over multiple calls', () => {
+    it('should generate randomized bandwidth_bytes values within valid range over multiple calls', () => {
       const events = Array.from({ length: 20 }, () => 
         buildRandomizedEventPayload('cloud-infra', 'test-customer')
       );
       
       events.forEach(event => {
-        expect(event.properties.bandwidth_MB).toBeGreaterThanOrEqual(100);
-        expect(event.properties.bandwidth_MB).toBeLessThanOrEqual(10000);
-        expect(typeof event.properties.bandwidth_MB).toBe('number');
+        expect(event.properties.bandwidth_bytes).toBeGreaterThanOrEqual(10000000);
+        expect(event.properties.bandwidth_bytes).toBeLessThanOrEqual(100000000);
+        expect(typeof event.properties.bandwidth_bytes).toBe('number');
       });
     });
 
@@ -214,7 +215,7 @@ describe('Event Templates', () => {
 
     it('should match the example payload structure from user requirements', () => {
       const manualProperties = {
-        bandwidth_MB: 5027,
+        bandwidth_bytes: 50000000,
         runtime: 'node'
       };
       
@@ -227,7 +228,7 @@ describe('Event Templates', () => {
         external_customer_id: 'acme',
         timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
         properties: {
-          bandwidth_MB: 5027,
+          bandwidth_bytes: 50000000,
           runtime: 'node'
         }
       });
@@ -238,7 +239,7 @@ describe('Event Templates', () => {
 
     it('should use customer_id when external_customer_id is not provided', () => {
       const manualProperties = {
-        bandwidth_MB: 2500,
+        bandwidth_bytes: 25000000,
         runtime: 'edge'
       };
       
@@ -248,7 +249,7 @@ describe('Event Templates', () => {
       expect(event.customer_id).toBe('NM56KxKNn855iUhe');
       expect(event.external_customer_id).toBeUndefined();
       expect(event.event_name).toBe('Nimbus_Scale_Network_Request');
-      expect(event.properties.bandwidth_MB).toBe(2500);
+      expect(event.properties.bandwidth_bytes).toBe(25000000);
       expect(event.properties.runtime).toBe('edge');
     });
   });

--- a/src/lib/events/event-templates.ts
+++ b/src/lib/events/event-templates.ts
@@ -41,14 +41,15 @@ export const AI_AGENTS_TEMPLATE: EventTemplate = {
 export const CLOUD_INFRA_TEMPLATE: EventTemplate = {
   eventName: 'Nimbus_Scale_Network_Request',
   properties: {
-    bandwidth_MB: {
+    bandwidth_bytes: {
       type: 'range',
-      min: 100,
-      max: 10000
+      min: 10000000,
+      max: 100000000
     },
     runtime: {
       type: 'enum',
-      options: ['node', 'edge']
+      options: ['node', 'edge'],
+      default: 'edge'
     }
   }
 };


### PR DESCRIPTION
- Update cloud infra template to use bandwidth_bytes (10M-100M range) instead of bandwidth_MB
- Create modular event form components:
  - CloudInfraEventsForm for bandwidth_bytes and runtime fields
  - AiAgentsEventsForm for AI agent-specific fields
  - GenericEventsForm for simple event sending
  - Refactor EventsCard to use composition pattern
- Update EventsCard to get instance from Zustand store instead of props
- Update all tests to use new bandwidth_bytes property and ranges
- Maintain backward compatibility with existing AI agents functionality

🤖 Generated with [Claude Code](https://claude.ai/code)